### PR TITLE
Rename roundTo to step and fix top of the hour issues.

### DIFF
--- a/components/time_picker/TimePicker.d.ts
+++ b/components/time_picker/TimePicker.d.ts
@@ -162,6 +162,10 @@ export interface TimePickerProps {
    */
   readonly?: boolean;
   /**
+   * Option to round to the given minute when picking a time
+   */
+  step?: number;
+  /**
    * Classnames object defining the component style.
    */
   theme?: TimePickerTheme;
@@ -173,10 +177,6 @@ export interface TimePickerProps {
    * Additional attributes passed to inner Input component.
    */
   [key: string]: any;
-  /**
-   * Option to round to the given minute when picking a time
-   */
-  roundTo?: number;
 }
 
 export class TimePicker extends React.Component<TimePickerProps, {}> { }

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -28,7 +28,7 @@ const factory = (TimePickerDialog, Input) => {
       onKeyPress: PropTypes.func,
       onOverlayClick: PropTypes.func,
       readonly: PropTypes.bool,
-      roundTo: PropTypes.number,
+      step: PropTypes.number,
       theme: PropTypes.shape({
         container: PropTypes.string,
         input: PropTypes.string,
@@ -92,7 +92,7 @@ const factory = (TimePickerDialog, Input) => {
       const {
         active, onDismiss, // eslint-disable-line
         cancelLabel, format, inputClassName, okLabel, onEscKeyDown, onOverlayClick,
-        readonly, value, ...others
+        readonly, value, step, ...others
       } = this.props;
       const formattedTime = value ? time.formatTime(value, format) : '';
       return (
@@ -123,7 +123,7 @@ const factory = (TimePickerDialog, Input) => {
             onSelect={this.handleSelect}
             theme={this.props.theme}
             value={this.props.value}
-            roundTo={this.props.roundTo}
+            step={this.props.step}
           />
         </div>
       );

--- a/components/time_picker/TimePickerDialog.js
+++ b/components/time_picker/TimePickerDialog.js
@@ -17,7 +17,7 @@ const factory = (Dialog) => {
       onEscKeyDown: PropTypes.func,
       onOverlayClick: PropTypes.func,
       onSelect: PropTypes.func,
-      roundTo: PropTypes.number,
+      step: PropTypes.number,
       theme: PropTypes.shape({
         am: PropTypes.string,
         amFormat: PropTypes.string,
@@ -46,12 +46,12 @@ const factory = (Dialog) => {
 
     state = {
       display: 'hours',
-      displayTime: new Date(this.props.value.getTime()),
+      displayTime: this.stepTime(new Date(this.props.value.getTime())),
     };
 
     componentWillReceiveProps(nextProps) {
       if (nextProps.value.getTime() !== this.state.displayTime.getTime()) {
-        this.setState({ displayTime: new Date(nextProps.value.getTime()) });
+        this.setState({ displayTime: this.stepTime(new Date(nextProps.value.getTime())) });
       }
     }
 
@@ -62,10 +62,7 @@ const factory = (Dialog) => {
     }
 
     handleClockChange = (value) => {
-      if (this.props.roundTo) {
-        value.setMinutes(Math.round(value.getMinutes() / this.props.roundTo) * this.props.roundTo);
-      }
-      this.setState({ displayTime: value });
+      this.setState({ displayTime: this.stepTime(value) });
     };
 
     handleSelect = (event) => {
@@ -79,6 +76,13 @@ const factory = (Dialog) => {
     handleHandMoved = () => {
       if (this.state.display === 'hours') this.setState({ display: 'minutes' });
     };
+
+    stepTime(value) {
+      if (this.props.step && value) {
+        value.setMinutes((Math.round(value.getMinutes() / this.props.step) * this.props.step) % 60);
+      }
+      return value;
+    }
 
     switchDisplay = (event) => {
       this.setState({ display: event.target.id });

--- a/components/time_picker/readme.md
+++ b/components/time_picker/readme.md
@@ -43,6 +43,7 @@ If you want to provide a theme via context, the component key is `RTTimePicker`.
 | `label`         | `String`    |             | The text string to use for the floating label element in the input component.|
 | `onChange`      | `Function`  |             | Callback called when the picker value is changed.|
 | `readonly`      | `Boolean`   |             | The input element will be readonly and look like disabled.|
+| `step`          | `Number`    |             | If step is set, minutes will be rounded to the nearest given interval. For example if step is 5 the minute hand can only select 5 minute marks.|
 | `value`         | `Date`      |             | Datetime object with currrently selected time. |
 
 ## Theme

--- a/spec/components/pickers.js
+++ b/spec/components/pickers.js
@@ -123,6 +123,16 @@ class PickersTest extends React.Component {
           onChange={this.handleChange.bind(this, 'time2')}
           value={this.state.time2}
         />
+
+        <TimePicker
+          format="ampm"
+          label="Time rounded to nearest 5 minute interval"
+          onChange={this.handleChange.bind(this, 'time3')}
+          onEscKeyDown={() => console.log('esc key down')}
+          onOverlayClick={() => console.log('overlay click')}
+          value={this.state.time3}
+          step={5}
+        />
       </section>
     );
   }


### PR DESCRIPTION
Renamed the roundTo prop on the TimePicker to be step.
Fixed issues when going from minute 55 to 0 that would cause the hours to change.
Fix the initial time so that it also is set to the nearest step.