### PR TITLE
Fix type definition for duration picker.

### DIFF
--- a/components/duration_picker/DurationPicker.d.ts
+++ b/components/duration_picker/DurationPicker.d.ts
@@ -183,6 +183,6 @@ export interface DurationPickerProps {
   [key: string]: any;
 }
 
-export class DurationPicker extends React.Component<DurationPicker, {}> { }
+export class DurationPicker extends React.Component<DurationPickerProps, {}> { }
 
 export default DurationPicker;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-toolbox",
   "description": "A set of React components implementing Google's Material Design specification with the power of CSS Modules.",
   "homepage": "http://www.react-toolbox.com",
-  "version": "2.0.0-beta.12-5",
+  "version": "2.0.0-beta.12-6",
   "main": "./lib",
   "module": "./components",
   "author": {


### PR DESCRIPTION
Fixed the type definition file for the duration picker so that it references the DurationPickerProps instead of recursively referencing itself as the props.
Updated version number.